### PR TITLE
Roles can also be assigned when admins create new users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,6 +18,7 @@ module Admin
 
     def create
       @user = User.new(user_params)
+      build_roles_for(@user)
 
       if @user.save
         flash[:notice] = 'User successfully created.'
@@ -36,10 +37,7 @@ module Admin
 
       User.transaction do
         @user.roles.clear
-        role_data = params.fetch(:roles, [])
-        role_data.each do |project_id, role_name|
-          role_name.present? && @user.roles.build(project_id: project_id, role: role_name)
-        end
+        build_roles_for(@user)
 
         if @user.update(user_params)
           flash[:notice] = 'User successfully updated.'
@@ -70,6 +68,13 @@ module Admin
 
     def set_projects
       @projects = Project.order(:name)
+    end
+
+    def build_roles_for(user)
+      role_data = params.fetch(:roles, [])
+      role_data.each do |project_id, role_name|
+        role_name.present? && @user.roles.build(project_id: project_id, role: role_name)
+      end
     end
 
     def user_params

--- a/spec/features/admin/managing_roles_spec.rb
+++ b/spec/features/admin/managing_roles_spec.rb
@@ -13,6 +13,20 @@ RSpec.feature "Admins can manage a user's roles" do
     login_as(admin)
   end
 
+  scenario 'when assigning roles to a new user' do
+    visit new_admin_user_path
+
+    fill_in 'Email', with: 'newuser@email.com'
+    fill_in 'Password', with: 'Password123'
+
+    select 'Editor', from: 'Internet Explorer'
+    click_button 'Create User'
+
+    click_link 'newuser@email.com'
+    expect(page).to have_content('Internet Explorer: Editor')
+    expect(page).not_to have_content('Sublime Text 3')
+  end
+
   scenario 'when assigning roles to an existing user' do
     visit admin_user_path(user)
     click_link 'Edit User'


### PR DESCRIPTION
Added Admins ability to immeditaly assign roles when creating new users.
Extracted repeated code into new 'build_roles_for(user)' method to be used by create and update user methods.
Added tests to cover new feature.