### PR TITLE
File uploads are persisted across form re-displays

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -64,6 +64,6 @@ class TicketsController < ApplicationController
   end
 
   def ticket_params
-    params.require(:ticket).permit(:name, :description, :attachment)
+    params.require(:ticket).permit(:name, :description, :attachment, :attachment_cache)
   end
 end

--- a/app/views/tickets/_ticket_form.html.erb
+++ b/app/views/tickets/_ticket_form.html.erb
@@ -2,5 +2,6 @@
   <%= f.input :name, placeholder: 'Ticket Name' %>
   <%= f.input :description, placeholder: 'Ticket description...' %>
   <%= f.input :attachment, as: :file, label: 'File' %>
+  <%= f.input :attachment_cache, as: :hidden %>
   <%= f.button :submit, class: 'btn btn-outline-primary' %>
 <% end %>

--- a/spec/features/creating_tickets_spec.rb
+++ b/spec/features/creating_tickets_spec.rb
@@ -54,4 +54,17 @@ RSpec.feature 'User can create new tickets' do
       expect(page).to have_content('speed.txt')
     end
   end
+
+  scenario 'persisting file uploads across form displays' do
+    attach_file 'File', 'spec/fixtures/speed.txt'
+    click_button 'Create Ticket'
+
+    fill_in 'Name', with: 'Add documentation for blink tag'
+    fill_in 'Description', with: 'The blink tag has a speed attribute'
+    click_button 'Create Ticket'
+
+    within('#ticket .attachment') do
+      expect(page).to have_content 'speed.txt'
+    end
+  end
 end


### PR DESCRIPTION
Setting CarrierWave to cache uploaded files in case of errors occurring when saving a ticket.
Setting the :attachment_cache field to be hidden.
Added a test to cover that feature.